### PR TITLE
docs: update specs to reflect Slice 1 implementation status

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -21,42 +21,50 @@ A local web app to help track game state while playing the board game **Frosthav
 
 ## Tech Stack
 
-| Layer | Choice |
-|---|---|
-| Language | TypeScript (strict) |
-| Framework | React |
-| Build | Vite |
-| Routing | React Router |
-| Testing | Vitest + Testing Library |
-| Persistence | JSON files on disk via Express API |
-| Backend | Express (lightweight local API server) |
-| State management | React Context + `useReducer` |
-| Package manager | pnpm |
+| Layer | Choice | Status |
+|---|---|---|
+| Language | TypeScript (strict) | ✅ |
+| Framework | React 19 | ✅ |
+| Build | Vite 7 | ✅ |
+| Routing | React Router 7 | ✅ installed, not yet used for page routing |
+| Testing | Vitest + Testing Library | ✅ |
+| Persistence | JSON files on disk via Express API | ✅ |
+| Backend | Express 5 (lightweight local API server) | ✅ |
+| State management | React Context + `useReducer` | ✅ |
+| UI | Tailwind CSS 4 + shadcn/ui components | ✅ |
+| Package manager | pnpm | ✅ |
 
 ## Architecture
 
 ```
 src/
-├── app/                  # App shell, router, layout
+├── api/                  # Client-side API helpers (fetch wrappers)
+│   └── scenarios.ts      # ✅
+├── components/ui/        # Shared UI components (shadcn/ui)
+│   ├── badge.tsx          # ✅
+│   ├── button.tsx         # ✅
+│   ├── card.tsx           # ✅
+│   ├── input.tsx          # ✅
+│   ├── label.tsx          # ✅
+│   └── toggle.tsx         # ✅
+├── data/                 # Static game reference data
+│   ├── conditions.ts      # ✅
+│   └── elements.ts        # ✅
 ├── features/
-│   ├── scenario/         # Scenario tracker (in-game phase)
-│   ├── campaign/         # Campaign & outpost phase tracking
-│   └── characters/       # Character creation & progression
-├── data/                 # Static game reference data (JSON)
-│   ├── conditions.ts
-│   ├── elements.ts
-│   └── classes/          # Starter class stats
-├── types/                # Shared TypeScript types
-└── components/           # Shared UI components
+│   ├── scenario/         # Scenario tracker (in-game phase) ✅
+│   ├── campaign/         # Campaign & outpost phase tracking (planned)
+│   └── characters/       # Character creation & progression (planned)
+├── lib/
+│   └── utils.ts          # ✅ cn() helper
+├── types/
+│   └── scenario.ts       # ✅
+├── App.tsx               # ✅ Root component (setup ↔ tracker flow)
+└── main.tsx              # ✅ Entry point
 
 server/
-├── index.ts              # Express app entry point
-├── routes/               # API route handlers
-└── storage.ts            # File system read/write helpers
+└── index.ts              # ✅ Express API (scenarios CRUD + file persistence)
 
 game-data/                # Persisted game state (JSON files, gitignored)
-├── campaigns/
-│   └── {campaign-id}.json
 └── scenarios/
     └── {session-id}.json
 ```
@@ -97,9 +105,24 @@ game-data/                # Persisted game state (JSON files, gitignored)
 
 ## Feature Slices
 
-### Slice 1: Scenario Tracker MVP
+### Slice 1: Scenario Tracker MVP ✅
 
-See [docs/features/scenario-tracker.md](./features/scenario-tracker.md)
+See [docs/features/scenario-tracker.md](./features/scenario-tracker.md) for detailed spec and acceptance criteria.
+
+**Implemented:**
+- Scenario setup form (name, characters, monster groups with standees)
+- Round counter with element auto-decay
+- Character HP/XP tracking with condition toggles
+- Monster group tracking with per-standee HP, conditions, kill/spawn
+- Element board (6 elements, click to toggle Strong/Inert, auto-decay on round advance)
+- Express API with JSON file persistence (`game-data/scenarios/`)
+- Auto-save on every state change, auto-load latest session on mount
+- Reducer with full test coverage (`scenarioReducer.test.ts`)
+- UI built with Tailwind CSS + shadcn/ui components
+
+**Not yet implemented from spec:**
+- React Router page routing (currently single-page conditional render)
+- Resume/select from multiple saved sessions (auto-loads latest only)
 
 ### Slice 2: Initiative & Turn Order (planned)
 

--- a/docs/features/scenario-tracker.md
+++ b/docs/features/scenario-tracker.md
@@ -214,17 +214,43 @@ DELETE /api/scenarios/:id      # Delete a session
 
 ## Acceptance Criteria
 
-- [ ] Can create a new scenario session with a name, characters, and monster groups
-- [ ] Round counter increments/decrements correctly
-- [ ] Element board displays all 6 elements with correct states
-- [ ] Elements decay on round advance (Strong → Waning → Inert)
-- [ ] Can manually set element to Strong or Inert
-- [ ] Character HP increments/decrements, clamped to 0–maxHp
-- [ ] Character XP increments/decrements, minimum 0
-- [ ] Conditions can be toggled on/off per character
-- [ ] Monster standees track individual HP and conditions
-- [ ] Standees can be killed (marked dead, removed from active view)
-- [ ] New standees/groups can be added mid-scenario
-- [ ] State survives page reload (loaded from JSON file on disk)
-- [ ] Can end/discard a session
-- [ ] Visual indicators for exhausted characters and dead monsters
+- [x] Can create a new scenario session with a name, characters, and monster groups
+- [x] Round counter increments/decrements correctly
+- [x] Element board displays all 6 elements with correct states
+- [x] Elements decay on round advance (Strong → Waning → Inert)
+- [x] Can manually set element to Strong or Inert
+- [x] Character HP increments/decrements, clamped to 0–maxHp
+- [x] Character XP increments/decrements, minimum 0
+- [x] Conditions can be toggled on/off per character
+- [x] Monster standees track individual HP and conditions
+- [x] Standees can be killed (marked dead, removed from active view)
+- [x] New standees/groups can be added mid-scenario
+- [x] State survives page reload (loaded from JSON file on disk)
+- [x] Can end/discard a session
+- [x] Visual indicators for exhausted characters and dead monsters
+
+## Implementation Notes
+
+### What was built
+
+| Component | File | Description |
+|---|---|---|
+| Types | `src/types/scenario.ts` | All data types as specced |
+| Reducer | `src/features/scenario/scenarioReducer.ts` | All actions implemented per spec |
+| Tests | `src/features/scenario/scenarioReducer.test.ts` | Full coverage of all reducer actions |
+| Context | `src/features/scenario/ScenarioContext.tsx` | Provider with auto-save/load via API |
+| API client | `src/api/scenarios.ts` | Fetch wrappers for all CRUD endpoints |
+| Server | `server/index.ts` | Express 5 API with file-based JSON persistence |
+| Setup UI | `src/features/scenario/ScenarioSetup.tsx` | Form for creating new scenarios |
+| Tracker UI | `src/features/scenario/ScenarioTracker.tsx` | Main tracker layout |
+| Round | `src/features/scenario/RoundTracker.tsx` | Round increment/decrement |
+| Elements | `src/features/scenario/ElementBoard.tsx` | 6-element grid with click-to-toggle |
+| Characters | `src/features/scenario/CharacterCard.tsx` | HP/XP/conditions per character |
+| Monsters | `src/features/scenario/MonsterGroupCard.tsx` | Group-level card with standee management |
+| Standees | `src/features/scenario/MonsterStandeeRow.tsx` | Per-standee HP/conditions/kill |
+
+### Deferred items
+
+- React Router page routing (app uses conditional render in `App.tsx` instead)
+- Session picker (auto-loads most recent session; no UI to choose from multiple)
+- Ally/summon tracking


### PR DESCRIPTION
Updates both spec files to reflect what's been built in Slice 1.

### Changes
- **SPEC.md**: Added version numbers to tech stack, added status column, updated architecture tree to match actual file structure, added Tailwind/shadcn to stack, marked Slice 1 as complete with summary
- **scenario-tracker.md**: Checked off all 14 acceptance criteria, added implementation notes table mapping components to files, documented deferred items

### Deferred from Slice 1
- React Router page routing (conditional render works fine for now)
- Session picker UI (auto-loads latest)
- Ally/summon tracking